### PR TITLE
Fix for issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,40 @@ A primitive DOT file is generated (graph.dot) along with the documentation. You 
 dot -Tpdf generated-docs/graph.dot  | open -f -a /Applications/Preview.app
 ```
 
+# Graph maintenance
+
+## Rebuilding the indexes
+
+Normally when new index is created it gets enabled and starts working from this moment. However, sometimes the existing data must be re-indexed - for example, if the new index is built on the data that already existed in the graph or after some sort of recovery.
+
+The schema manager can re-index either one named index, all defined indexes, new ones created during last run or all indexes that are not currently in usable state.
+
+
+### Reindex one specific index
+
+```
+bin/schema_manager.sh  -g graph.properties -i index-name -w schema.json
+```
+
+### Reindex everything
+
+```
+bin/schema_manager.sh  -g graph.properties -r ALL -w schema.json
+```
+
+### Reindex only newly created indexes
+
+```
+bin/schema_manager.sh  -g graph.properties -r NEW -w schema.json
+```
+
+### Reindex only unavailable indexes
+
+```
+bin/schema_manager.sh  -g graph.properties -r UNAVAILABLE -w schema.json
+```
+
+In this case the state of each index defined in the schema will be verified. If an index or any of its properties is in the state REGISTERED or INSTALLED, the tool will re-index the data and enable the index. If the index or any of its components is in DISABLED state, it will be ignored.
 
 
 # Plans for future

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<junit.version>4.12</junit.version>
+		<mockito.core.version>2.16.0</mockito.core.version>
 		<apache.cli.version>1.4</apache.cli.version>
 		<log4j.version>1.7.21</log4j.version>
 		<log4j2.version>2.9.1</log4j2.version>
@@ -18,7 +20,7 @@
 		<commons.lang.version>2.6</commons.lang.version>
 		<commons.math3.version>3.6.1</commons.math3.version>
 		<json.schema.validator.version>2.2.6</json.schema.validator.version>
-		<janusgraph.version>0.2.0</janusgraph.version>
+		<janusgraph.version>0.3.0-SNAPSHOT</janusgraph.version>
 		<tinkerpop.version>3.2.6</tinkerpop.version>
 		<janusgraph.dynamodb.version>1.1.0</janusgraph.dynamodb.version>
 		<dynamodb.local.version>1.11.86</dynamodb.local.version>
@@ -47,10 +49,16 @@
 			<version>${apache.cli.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
-			<scope>test</scope>
+		    <groupId>junit</groupId>
+		    <artifactId>junit</artifactId>
+		    <version>${junit.version}</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-core</artifactId>
+		    <version>${mockito.core.version}</version>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<commons.lang.version>2.6</commons.lang.version>
 		<commons.math3.version>3.6.1</commons.math3.version>
 		<json.schema.validator.version>2.2.6</json.schema.validator.version>
-		<janusgraph.version>0.3.0-SNAPSHOT</janusgraph.version>
+		<janusgraph.version>0.2.0</janusgraph.version>
 		<tinkerpop.version>3.2.6</tinkerpop.version>
 		<janusgraph.dynamodb.version>1.1.0</janusgraph.dynamodb.version>
 		<dynamodb.local.version>1.11.86</dynamodb.local.version>

--- a/src/main/java/com/newforma/titan/schema/IndexUtils.java
+++ b/src/main/java/com/newforma/titan/schema/IndexUtils.java
@@ -1,0 +1,90 @@
+package com.newforma.titan.schema;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.JanusGraphManagement;
+import org.janusgraph.core.schema.RelationTypeIndex;
+import org.janusgraph.core.schema.SchemaStatus;
+
+import com.newforma.titan.schema.types.GraphIndexDef;
+import com.newforma.titan.schema.types.LocalEdgeIndexDef;
+import com.newforma.titan.schema.types.LocalPropertyIndexDef;
+
+public class IndexUtils {
+
+    /**
+     * Returns the collection of the graph indexes that are in either
+     * {@link SchemaStatus#INSTALLED} or {@link SchemaStatus#REGISTERED} status.
+     * Note that if <b>any</b> property key is in above-mentioned state but
+     * <b>no</b> property key is in {@link SchemaStatus#DISABLED} state, then
+     * the index is returned.
+     *
+     * @param candidates
+     *            list of indexes to consider
+     * @param graph
+     *            open graph instance
+     * @return list of indexes that are not currently available but not disabled
+     *
+     * @throws SchemaManagementException
+     *             if an index discovery operation fails
+     */
+    public static Collection<String> getUnavailableIndexes(final Collection<String> candidates, final GraphState graphState,
+            final JanusGraph graph) throws SchemaManagementException {
+
+        final JanusGraphManagement mgmt = graph.openManagement();
+
+        final Set<String> unavailableIndexes = new HashSet<>();
+
+        try {
+            candidates.stream().filter(n -> graphState.getIndexDef(n) instanceof LocalPropertyIndexDef).filter(n -> {
+                final LocalPropertyIndexDef def = (LocalPropertyIndexDef) graphState.getIndexDef(n);
+                final PropertyKey pk = graph.getPropertyKey(def.getKey());
+                if (pk == null) {
+                    return false;
+                }
+                final RelationTypeIndex idx = mgmt.getRelationIndex(pk, n);
+                return idx.getIndexStatus() == SchemaStatus.INSTALLED
+                        || idx.getIndexStatus() == SchemaStatus.REGISTERED;
+            }).forEach(unavailableIndexes::add);
+
+            candidates.stream().filter(n -> graphState.getIndexDef(n) instanceof LocalEdgeIndexDef).filter(n -> {
+                final LocalEdgeIndexDef def = (LocalEdgeIndexDef) graphState.getIndexDef(n);
+                final EdgeLabel edge = graph.getEdgeLabel(def.getLabel());
+                if (edge == null) {
+                    return false;
+                }
+                final RelationTypeIndex idx = mgmt.getRelationIndex(edge, n);
+                return idx.getIndexStatus() == SchemaStatus.INSTALLED
+                        || idx.getIndexStatus() == SchemaStatus.REGISTERED;
+            }).forEach(unavailableIndexes::add);
+
+            candidates.stream().filter(n -> graphState.getIndexDef(n) instanceof GraphIndexDef).filter(n -> {
+                final JanusGraphIndex idx = mgmt.getGraphIndex(n);
+
+                final int numUnavailableKeys = Arrays.stream(idx.getFieldKeys()).mapToInt(k -> {
+                    final SchemaStatus status = idx.getIndexStatus(k);
+                    if (status == SchemaStatus.DISABLED) {
+                        return -idx.getFieldKeys().length;
+                    }
+                    return status == SchemaStatus.INSTALLED || status == SchemaStatus.REGISTERED ? 1 : 0;
+                }).sum();
+
+                return numUnavailableKeys > 0;
+            }).forEach(unavailableIndexes::add);
+        } catch (final Exception e) {
+            throw new SchemaManagementException("Unable to verify the indexes", e);
+        } finally {
+            mgmt.rollback();
+        }
+
+        return unavailableIndexes;
+
+    }
+}

--- a/src/main/java/com/newforma/titan/schema/SchemaManager.java
+++ b/src/main/java/com/newforma/titan/schema/SchemaManager.java
@@ -116,7 +116,7 @@ public class SchemaManager {
 		this.graphMLFileToSave = graphMLFileToSave;
 		return this;
 	}
-	
+
 	public SchemaManager reindexingTimeout(int timeoutInSecs) {
 		this.reindexTimeoutInSecs = timeoutInSecs;
 		return this;
@@ -150,9 +150,9 @@ public class SchemaManager {
 		} catch (ConfigurationException e) {
 			throw new SchemaManagementException("Failed to load graph configuration from " + graphConfigFileName, e);
 		}
-		
+
 		final JanusGraph graph = JanusGraphFactory.open(graphConfig);
-		
+
 		try {
 
 			LOG.info("Graph connection successful");
@@ -231,6 +231,12 @@ public class SchemaManager {
 					updateSingleIndex(graphState, graph, indexName, action.getMethod());
 				}
 				break;
+            case UNAVAILABLE:
+                for(final String indexName: IndexUtils.getUnavailableIndexes(graphState.getAllIndexes(), graphState, graph)) {
+                    LOG.info("Index {} is not available, updating", indexName);
+                    updateSingleIndex(graphState, graph, indexName, action.getMethod());
+                }
+                break;
 			default:
 				throw new RuntimeException("Unsupported value " + action.getTarget());
 			}
@@ -243,7 +249,7 @@ public class SchemaManager {
 		Object indexDef = graphState.getIndexDef(indexName);
 
 		if (indexDef == null) {
-		    throw new SchemaManagementException("Unkniwn index " + indexName);
+		    throw new SchemaManagementException("Unknown index " + indexName);
 		}
 
 		try {

--- a/src/main/java/com/newforma/titan/schema/SchemaManagerApp.java
+++ b/src/main/java/com/newforma/titan/schema/SchemaManagerApp.java
@@ -66,7 +66,7 @@ public class SchemaManagerApp {
         if (cmdLine.hasOption(OPTION_REINDEX_SPECIFIC)) {
             reindexActions.add(new ReindexAction(IndexTarget.NAMED, indexingMethod, cmdLine.getOptionValue(OPTION_REINDEX_SPECIFIC)));
         }
-        
+
         int reindexTimeoutInSecs = SchemaManager.DEFAULT_INDEX_REGISTERED_TIMEOUT_SECS;
         if (cmdLine.hasOption(OPTION_REINDEX_TIMEOUT)) {
         	reindexTimeoutInSecs = Integer.parseInt(cmdLine.getOptionValue(OPTION_REINDEX_TIMEOUT));
@@ -96,7 +96,7 @@ public class SchemaManagerApp {
     private static Options populateOptions() {
         final Options options = new Options();
         options.addOption(OPTION_WRITE_TO_DB, false, "Write the relations defined by the schema to the graph");
-        options.addOption(OPTION_REINDEX_DATA, true, "Reindex data: ALL, NEW");
+        options.addOption(OPTION_REINDEX_DATA, true, "Reindex data: ALL, NEW, UNAVAILABLE");
         options.addOption(OPTION_REINDEX_SPECIFIC, true, "Reindex the specific index after applying the schema");
         options.addOption(OPTION_INDEXING_METHOD, true, "Using the specific indexing method: one of " +
                 StringUtils.join(ReindexAction.IndexingMethod.values(), ',') + " ("  +

--- a/src/main/java/com/newforma/titan/schema/actions/ReindexAction.java
+++ b/src/main/java/com/newforma/titan/schema/actions/ReindexAction.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang.StringUtils;
 import com.google.common.base.Preconditions;
 
 public class ReindexAction {
-	public enum IndexTarget { ALL, NEW, NAMED }
+	public enum IndexTarget { ALL, NEW, NAMED, UNAVAILABLE }
 
 	public enum IndexingMethod { LOCAL, HADOOP, HADOOP2 }
 

--- a/src/test/java/com/newforma/titan/schema/IndexUtilsTest.java
+++ b/src/test/java/com/newforma/titan/schema/IndexUtilsTest.java
@@ -1,0 +1,162 @@
+package com.newforma.titan.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.janusgraph.core.EdgeLabel;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.PropertyKey;
+import org.janusgraph.core.schema.JanusGraphIndex;
+import org.janusgraph.core.schema.RelationTypeIndex;
+import org.janusgraph.core.schema.SchemaStatus;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.newforma.titan.schema.types.GraphIndexDef;
+import com.newforma.titan.schema.types.LocalEdgeIndexDef;
+import com.newforma.titan.schema.types.LocalPropertyIndexDef;
+
+public class IndexUtilsTest {
+
+
+    @Mock
+    private JanusGraph graph;
+
+    @Mock
+    private GraphState graphState;
+
+    @Mock
+    private ManagementSystem mgmt;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(graph.openManagement()).thenReturn(mgmt);
+    }
+
+
+    @Test
+    public void getUnavailableIndexes_localEdgeIndex() throws SchemaManagementException {
+
+        final List<SchemaStatus> indexStatuses = Arrays.asList(
+                    SchemaStatus.DISABLED,
+                    SchemaStatus.INSTALLED,
+                    SchemaStatus.REGISTERED,
+                    SchemaStatus.ENABLED
+                );
+
+        for(int i = 0 ; i < indexStatuses.size(); i++) {
+            final LocalEdgeIndexDef leIdx = Mockito.mock(LocalEdgeIndexDef.class);
+            when(graphState.getIndexDef("index" + i)).thenReturn(leIdx);
+            when(leIdx.getLabel()).thenReturn("edgeLabel" + i);
+
+            final EdgeLabel el = Mockito.mock(EdgeLabel.class);
+
+            when(graph.getEdgeLabel("edgeLabel" + i)).thenReturn(el);
+
+            final RelationTypeIndex rti = Mockito.mock(RelationTypeIndex.class);
+            when(mgmt.getRelationIndex(eq(el), eq("index" + i))).thenReturn(rti);
+            when(rti.getIndexStatus()).thenReturn(indexStatuses.get(i));
+        }
+
+        final Collection<String> unavailableIndexes = IndexUtils
+                .getUnavailableIndexes(Arrays.asList("index0", "index1", "index2", "index3"), graphState, graph);
+
+        assertEquals(2, unavailableIndexes.size());
+        assertTrue(unavailableIndexes.contains("index1"));
+        assertTrue(unavailableIndexes.contains("index2"));
+    }
+
+    @Test
+    public void getUnavailableIndexes_localPropertyIndex() throws SchemaManagementException {
+
+        final List<SchemaStatus> indexStatuses = Arrays.asList(
+                    SchemaStatus.DISABLED,
+                    SchemaStatus.INSTALLED,
+                    SchemaStatus.REGISTERED,
+                    SchemaStatus.ENABLED
+                );
+
+        for(int i = 0 ; i < indexStatuses.size(); i++) {
+            final LocalPropertyIndexDef lpIdx = Mockito.mock(LocalPropertyIndexDef.class);
+            when(graphState.getIndexDef("index" + i)).thenReturn(lpIdx);
+            when(lpIdx.getKey()).thenReturn("property" + i);
+
+            final PropertyKey pk = Mockito.mock(PropertyKey.class);
+
+            when(graph.getPropertyKey("property" + i)).thenReturn(pk);
+
+            final RelationTypeIndex rti = Mockito.mock(RelationTypeIndex.class);
+            when(mgmt.getRelationIndex(eq(pk), eq("index" + i))).thenReturn(rti);
+            when(rti.getIndexStatus()).thenReturn(indexStatuses.get(i));
+        }
+
+        final Collection<String> unavailableIndexes = IndexUtils
+                .getUnavailableIndexes(Arrays.asList("index0", "index1", "index2", "index3"), graphState, graph);
+
+        assertEquals(2, unavailableIndexes.size());
+        assertTrue(unavailableIndexes.contains("index1"));
+        assertTrue(unavailableIndexes.contains("index2"));
+    }
+
+    @Test
+    public void getUnavailableIndexes_graphIndex() throws SchemaManagementException {
+
+        final List<SchemaStatus[]> indexStatuses = Arrays.asList(
+                    new SchemaStatus[]{SchemaStatus.DISABLED},          // index0
+                    new SchemaStatus[]{SchemaStatus.INSTALLED},         // index1
+                    new SchemaStatus[]{SchemaStatus.REGISTERED},        // index2
+                    new SchemaStatus[]{SchemaStatus.ENABLED},           // index3
+                    new SchemaStatus[]{SchemaStatus.INSTALLED, SchemaStatus.DISABLED},      // index4
+                    new SchemaStatus[]{SchemaStatus.REGISTERED, SchemaStatus.DISABLED},     // index5
+                    new SchemaStatus[]{SchemaStatus.ENABLED, SchemaStatus.DISABLED},        // index6
+                    new SchemaStatus[]{SchemaStatus.ENABLED, SchemaStatus.INSTALLED},       // index7
+                    new SchemaStatus[]{SchemaStatus.REGISTERED, SchemaStatus.INSTALLED}      // index8
+
+                );
+
+        final Collection<String> indexNames = new ArrayList<>(indexStatuses.size());
+        for(int i = 0 ; i < indexStatuses.size(); i++) {
+
+            indexNames.add("index" + i);
+
+            final GraphIndexDef lpIdx = Mockito.mock(GraphIndexDef.class);
+            when(graphState.getIndexDef("index" + i)).thenReturn(lpIdx);
+
+            final JanusGraphIndex jgi = Mockito.mock(JanusGraphIndex.class);
+            when(mgmt.getGraphIndex(eq("index" + i))).thenReturn(jgi);
+
+            final SchemaStatus[] pkStatuses = indexStatuses.get(i);
+            final PropertyKey[] pkis = new PropertyKey[pkStatuses.length];
+            for(int pkIdx = 0; pkIdx < pkis.length; pkIdx++) {
+                final String pkName = "property" + i + "_" + pkIdx;
+                final PropertyKey pk = Mockito.mock(PropertyKey.class);
+                pkis[pkIdx] = pk;
+                when(graph.getPropertyKey(eq(pkName))).thenReturn(pk);
+                when(jgi.getIndexStatus(eq(pk))).thenReturn(pkStatuses[pkIdx]);
+            }
+
+            when(jgi.getFieldKeys()).thenReturn(pkis);
+        }
+
+        final Collection<String> unavailableIndexes = IndexUtils
+                .getUnavailableIndexes(indexNames, graphState, graph);
+
+        assertEquals(4, unavailableIndexes.size());
+        assertTrue(unavailableIndexes.contains("index1"));
+        assertTrue(unavailableIndexes.contains("index2"));
+        assertTrue(unavailableIndexes.contains("index7"));
+        assertTrue(unavailableIndexes.contains("index8"));
+    }
+}


### PR DESCRIPTION
Add new reindexing target "UNAVAILABLE" which selects all indexes that
are not ENABLED or DISABLED. For the graph indexes the state of each
index property key is taken into account, e.g. if the index status for
at least one property is INSTALLED or REGISTERED but there is no
property with the state DISABLED, then the index will be selected for
update (recovery / reindexing). This option can be used when a previous
graph schema update fails for any reason. It only selects the indexes
defined in the schema.

Signed-off-by: Nikolai Grigoriev <ngrigoriev@newforma.com>