### PR TITLE
Updated the Jackson library version to 2.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.newforma</groupId>
 	<artifactId>janusgraph-schema-manager</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT</version>
 	<name>janusgraph-schema-manager</name>
 	<url>http://maven.apache.org</url>
 
@@ -16,7 +16,7 @@
 		<apache.cli.version>1.4</apache.cli.version>
 		<log4j.version>1.7.21</log4j.version>
 		<log4j2.version>2.9.1</log4j2.version>
-		<jackson.version>2.8.8</jackson.version>
+		<jackson.version>2.8.11</jackson.version>
 		<commons.lang.version>2.6</commons.lang.version>
 		<commons.math3.version>3.6.1</commons.math3.version>
 		<json.schema.validator.version>2.2.6</json.schema.validator.version>


### PR DESCRIPTION
Updated the Jackson library version to 2.8.11 to fix the CVE-2017-7525, CVE-2018-7489 and CVE-2017-17485 high severity vulnerabilities.